### PR TITLE
#36 aio config and aio config:get without key should return valid JSON

### DIFF
--- a/src/commands/config/get.js
+++ b/src/commands/config/get.js
@@ -10,23 +10,23 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { Command } = require('@oclif/command')
+const { Command, flags } = require('@oclif/command')
 const Conf = require('conf')
 
 class GetCommand extends Command {
   async run () {
-    const { args } = this.parse(GetCommand)
+    const { args, flags } = this.parse(GetCommand)
 
     let retVal = await this.get(args.key)
     if (retVal) {
       this.log(retVal)
     }
-    return retVal
+    return (flags.json) ? JSON.stringify(retVal) : retVal
   }
 
   async get (key) {
     const conf = new Conf()
-    return (key) ? conf.get(key) : JSON.stringify(Object.assign({}, conf.store))
+    return (key) ? conf.get(key) : conf.store
   }
 }
 
@@ -35,5 +35,9 @@ GetCommand.description = 'gets a persistent config value'
 GetCommand.args = [
   { name: 'key' }
 ]
+
+GetCommand.flags = {
+  json: flags.boolean({ char: 'j', description: 'format as JSON' })
+}
 
 module.exports = GetCommand

--- a/src/commands/config/get.js
+++ b/src/commands/config/get.js
@@ -26,7 +26,7 @@ class GetCommand extends Command {
 
   async get (key) {
     const conf = new Conf()
-    return (key) ? conf.get(key) : conf.store
+    return (key) ? conf.get(key) : JSON.stringify(Object.assign({}, conf.store))
   }
 }
 

--- a/test/commands/config/__mocks__/conf.js
+++ b/test/commands/config/__mocks__/conf.js
@@ -12,9 +12,10 @@ governing permissions and limitations under the License.
 
 const mock = jest.fn().mockImplementation(
   function () { // constructor
-    let _store = {
+    const plainObject = () => Object.create(null);
+    let _store = Object.assign(plainObject(), {
       known_key: 'known_value'
-    }
+    })
 
     // set properties and functions for object
     // this is how you can get the call stats on the mock instance,

--- a/test/commands/config/get.test.js
+++ b/test/commands/config/get.test.js
@@ -16,7 +16,7 @@ jest.mock('conf')
 
 test('no key', async () => {
   let val = await GetCommand.run([])
-  return expect(val).toEqual({ known_key: 'known_value' })
+  return expect(JSON.parse(val)).toEqual({ known_key: 'known_value' })
 })
 
 test('undefined key', async () => {

--- a/test/commands/config/get.test.js
+++ b/test/commands/config/get.test.js
@@ -16,7 +16,7 @@ jest.mock('conf')
 
 test('no key', async () => {
   let val = await GetCommand.run([])
-  return expect(JSON.parse(val)).toEqual({ known_key: 'known_value' })
+  return expect(val).toEqual({ known_key: 'known_value' })
 })
 
 test('undefined key', async () => {
@@ -27,4 +27,34 @@ test('undefined key', async () => {
 test('defined key', async () => {
   let val = await GetCommand.run(['known_key'])
   return expect(val).toEqual('known_value')
+})
+
+test('no key, -j', async () => {
+  let val = await GetCommand.run(['-j'])
+  return expect(JSON.parse(val)).toEqual({ known_key: 'known_value' })
+})
+
+test('undefined key, -j', async () => {
+  let val = await GetCommand.run(['-j', 'unknown'])
+  return expect(val).toBeUndefined()
+})
+
+test('defined key, -j', async () => {
+  let val = await GetCommand.run(['-j', 'known_key'])
+  return expect(JSON.parse(val)).toEqual('known_value')
+})
+
+test('no key, --json', async () => {
+  let val = await GetCommand.run(['--json'])
+  return expect(JSON.parse(val)).toEqual({ known_key: 'known_value' })
+})
+
+test('undefined key, --json', async () => {
+  let val = await GetCommand.run(['--json', 'unknown'])
+  return expect(val).toBeUndefined()
+})
+
+test('defined key, --json', async () => {
+  let val = await GetCommand.run(['--json', 'known_key'])
+  return expect(JSON.parse(val)).toEqual('known_value')
 })


### PR DESCRIPTION
## Description

Assign the own objects of the config store to an empty object and JSON.stringify the that object

## Related Issue

#36 aio config and aio config:get without key should return valid JSON

## Motivation and Context

Goal is to be able to post-process the configuration object in scripts

## How Has This Been Tested?

Using the command line examples in the issue #36 

## Screenshots (if appropriate):

n/a

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.