### PR TITLE
Node namespace 14

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^4.5.4"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": "^14.18 || ^16.13 || >=18"
   },
   "files": [
     "/oclif.manifest.json",


### PR DESCRIPTION
This pr bumps node support to LTS versions and drops support for 12 which is EOL
Minor version choices are to ensure we get node: namespace supporting versions of node. 