### PR TITLE
fix: ACNA-2799 - code links in README point to a .ts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,10 @@ $ aio config --help...
 <!-- commands -->
 * [`aio config`](#aio-config)
 * [`aio config clear`](#aio-config-clear)
-* [`aio config del KEYS...`](#aio-config-del-keys)
 * [`aio config delete KEYS...`](#aio-config-delete-keys)
 * [`aio config edit`](#aio-config-edit)
 * [`aio config get KEY`](#aio-config-get-key)
 * [`aio config list`](#aio-config-list)
-* [`aio config ls`](#aio-config-ls)
-* [`aio config rm KEYS...`](#aio-config-rm-keys)
 * [`aio config set key 'a value'       # set key to 'a value'`](#aio-config-set-key-a-value--------set-key-to-a-value)
 
 ## `aio config`
@@ -82,7 +79,7 @@ EXAMPLES
   $ aio config:clear
 ```
 
-_See code: [src/commands/config/index.ts](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/index.ts)_
+_See code: [src/commands/config/index.js](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/index.js)_
 
 ## `aio config clear`
 
@@ -101,27 +98,7 @@ DESCRIPTION
   clears all persistent config values
 ```
 
-_See code: [src/commands/config/clear.ts](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/clear.ts)_
-
-## `aio config del KEYS...`
-
-deletes persistent config values
-
-```
-USAGE
-  $ aio config del KEYS... [-l | -g]
-
-FLAGS
-  -g, --global  global config
-  -l, --local   local config
-
-DESCRIPTION
-  deletes persistent config values
-
-ALIASES
-  $ aio config del
-  $ aio config rm
-```
+_See code: [src/commands/config/clear.js](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/clear.js)_
 
 ## `aio config delete KEYS...`
 
@@ -143,7 +120,7 @@ ALIASES
   $ aio config rm
 ```
 
-_See code: [src/commands/config/delete.ts](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/delete.ts)_
+_See code: [src/commands/config/delete.js](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/delete.js)_
 
 ## `aio config edit`
 
@@ -161,7 +138,7 @@ DESCRIPTION
   edit config file
 ```
 
-_See code: [src/commands/config/edit.ts](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/edit.ts)_
+_See code: [src/commands/config/edit.js](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/edit.js)_
 
 ## `aio config get KEY`
 
@@ -182,7 +159,7 @@ DESCRIPTION
   gets a persistent config value
 ```
 
-_See code: [src/commands/config/get.ts](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/get.ts)_
+_See code: [src/commands/config/get.js](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/get.js)_
 
 ## `aio config list`
 
@@ -207,61 +184,7 @@ ALIASES
   $ aio config ls
 ```
 
-_See code: [src/commands/config/list.ts](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/list.ts)_
-
-## `aio config ls`
-
-list, get, set, delete, and edit persistent configuration data
-
-```
-USAGE
-  $ aio config ls [-l | -g] [-e] [--verbose |  | [-j | -y]]
-
-FLAGS
-  -e, --env     environment variables
-  -g, --global  global config
-  -j, --json    output in json
-  -l, --local   local config
-  -y, --yaml    output in yaml
-  --verbose     show all config values
-
-DESCRIPTION
-  list, get, set, delete, and edit persistent configuration data
-
-ALIASES
-  $ aio config ls
-
-EXAMPLES
-  $ aio config:list
-
-  $ aio config:get KEY
-
-  $ aio config:set KEY VALUE
-
-  $ aio config:delete KEY
-
-  $ aio config:clear
-```
-
-## `aio config rm KEYS...`
-
-deletes persistent config values
-
-```
-USAGE
-  $ aio config rm KEYS... [-l | -g]
-
-FLAGS
-  -g, --global  global config
-  -l, --local   local config
-
-DESCRIPTION
-  deletes persistent config values
-
-ALIASES
-  $ aio config del
-  $ aio config rm
-```
+_See code: [src/commands/config/list.js](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/list.js)_
 
 ## `aio config set key 'a value'       # set key to 'a value'`
 
@@ -285,5 +208,5 @@ DESCRIPTION
   sets a persistent config value
 ```
 
-_See code: [src/commands/config/set.ts](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/set.ts)_
+_See code: [src/commands/config/set.js](https://github.com/adobe/aio-cli-plugin-config/blob/5.0.0/src/commands/config/set.js)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
-    "@adobe/eslint-config-aio-lib-config": "^2.0.1",
+    "@adobe/eslint-config-aio-lib-config": "^3.0.0",
     "acorn": "^8.7.0",
     "chalk": "^4.0.0",
     "eslint": "^8.46.0",
@@ -31,8 +31,7 @@
     "jest-junit": "^16.0.0",
     "jest-resolve": "^29.5.0",
     "oclif": "^3.2.0",
-    "stdout-stderr": "^0.1.13",
-    "typescript": "^5.1.6"
+    "stdout-stderr": "^0.1.13"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
closes #150

## How Has This Been Tested?

1. rm -rf node_modules
2. npm i
3. npm test
4. npm run prepack
5. Inspect README.md for `See code:` links (should point to the `.js` file)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.